### PR TITLE
use clay `%cult` endpoint for more reliable sub count data

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ vita: our %radio has 326 subs
 
 to unregister a desk: `:vita|d %kids`. WARNING: all data collected on an unregistered desk will be lost.
 
-once every 24 hours, `:vita` grabs downloads metrics on each registered desk using `.^((set ship) %cs /=mydesk=/subs)`. every time this scry is performed, `:vita` logs the size of the set with a timestamp. `:vita` keeps one copy of the latest full set of downloaders, and a cumulative set of all unique downloaders.
+once every 24 hours, `:vita` grabs downloads metrics on each registered desk using `.^((set [@p rave:clay]) %cx /=//=/cult/mydesk)` (filtered by ships watching the latest desk version). every time this scry is performed, `:vita` logs the size of the set with a timestamp. `:vita` keeps one copy of the latest full set of downloaders, and a cumulative set of all unique downloaders.
 
 when users unsync from your local desk, `latest.downloads` wont go down until your next `|commit` to the desk.
 `cumulative.downloads` only goes up.
@@ -113,13 +113,24 @@ the vita frontend displays the data collected by `:vita` plus some forms for app
 
 ## install from source
 
-1. create a blank `%vita` desk.
-2. copy in basic app dependencies.
+1. ```bash
+   rm -rI vita-full/
+   find vita -type f | while read f; do { d=$(dirname "$f" | sed "s/^vita/vita-full/"); mkdir -p "$d"; ln -sr -t "$d" "$f"; }; done
+   git clone -b 411k --depth 1 https://github.com/urbit/urbit.git urb
+   cp urb/pkg/arvo/lib/{agentio*,verb*,strand*} vita-full/lib/
+   cp urb/pkg/arvo/sur/{spider*,verb*} vita-full/sur/
+   git clone -b sl/server-schooner-z412k --depth 1 https://github.com/sidnym-ladrut/yard.git yar
+   cp yar/desk/lib/{dbug*,default-agent*,skeleton*,rudder*,server*,docket*,mip*} vita-full/lib/
+   cp yar/desk/mar/{bill*,docket*,hoon*,kelvin*,mime*,noun*,ship*,json*} vita-full/mar/
+   cp yar/desk/sur/docket* vita-full/sur/
+   git clone -b v1.25.0 --depth 1 https://github.com/tloncorp/landscape.git lan
+   cp lan/desk/sur/treaty* vita-full/sur/
+   ```
+2. `|new-desk %vita`
 3. `|mount %vita`
-4. cd `<this_repo>/vita`
-5. `./install.sh -w <my_pier>/vita`
-6. `|commit %vita`
-7. `|install our %vita`
+4. `rm -rf <my_pier>/vita/*; cp -rf <this-repo>/vita-full <my_pier>/vita`
+5. `|commit %vita`
+6. `|install our %vita`
 
 ## urbit.org grant
 

--- a/vita-client/gen/toggle-vita.hoon
+++ b/vita-client/gen/toggle-vita.hoon
@@ -1,10 +1,10 @@
 ::  Tell app whether to share usage data with :vita
 ::
-:: :myagent +mydesk!share-usage
+:: :myagent +mydesk!toggle-vita
 ::   enables sharing
-:: :myagent +mydesk!share-usage &
+:: :myagent +mydesk!toggle-vita &
 ::   enables sharing
-:: :myagent +mydesk!share-usage |
+:: :myagent +mydesk!toggle-vita |
 ::   disables sharing
 ::
 :-  %say

--- a/vita-client/lib/vita-client.hoon
+++ b/vita-client/lib/vita-client.hoon
@@ -132,7 +132,14 @@
     ++  on-peek
       |=  =path
       ^-  (unit (unit cage))
-      (on-peek:ag path)
+      ?.  ?=([@ %vita *] path)
+        (on-peek:ag path)
+      ?+  path  [~ ~]
+        [%u %vita ~]           ``noun+!>(&)
+        [%x %vita %last ~]     ``noun+!>(last)
+        [%x %vita %enabled ~]  ``noun+!>(enabled.config)
+        [%x %vita %parent ~]   ``noun+!>(vita-parent.config)
+      ==
     ::
     ++  on-agent
       |=  [=wire =sign:agent:gall]

--- a/vita-client/lib/vita-client.hoon
+++ b/vita-client/lib/vita-client.hoon
@@ -102,10 +102,10 @@
           `this(config cfg.pok)
             %log-activity
           ?.  enabled.config
-            :: %-  (slog leaf+"{<dap.bowl>} vita-client: not sending activity, disabled." ~)
+            ::  %-  (slog leaf+"{<dap.bowl>} vita-client: not sending activity, disabled." ~)
             `this
           ?.  (gth now.bowl (add last ~h8)) ::TODO ~d1 constant?
-            %-  (slog leaf+"{<dap.bowl>} vita-client: not sending activity. already sent." ~)
+            ::  %-  (slog leaf+"{<dap.bowl>} vita-client: not sending activity. already sent." ~)
             `this
           =.  last  now.bowl
           :_  this

--- a/vita-client/lib/vita-client.hoon
+++ b/vita-client/lib/vita-client.hoon
@@ -6,7 +6,7 @@
 ::   from somewhere that indicates real user activity
 ::
 :: on %log-activity, we check if we already poked :~parent/vita today.
-:: if so, ignore. if not, poke :~parent/vita with 
+:: if so, ignore. if not, poke :~parent/vita with
 ::
 :: on init, vita-client can be set to be enabled / disabled by default.
 :: on init, vita-client is configured with its parent @p
@@ -132,7 +132,13 @@
     ++  on-peek
       |=  =path
       ^-  (unit (unit cage))
-      (on-peek:ag path)
+      ?.  ?=([@ %vita *] path)
+        (on-peek:ag path)
+      ?+  path  [~ ~]
+        [%u %vita ~]                 ``noun+!>(&)
+        [%x %vita %last ~]           ``noun+!>(last)
+        [%x %vita %enabled ~]        ``noun+!>(enabled.config)
+      ==
     ::
     ++  on-agent
       |=  [=wire =sign:agent:gall]

--- a/vita-client/lib/vita-client.hoon
+++ b/vita-client/lib/vita-client.hoon
@@ -132,13 +132,7 @@
     ++  on-peek
       |=  =path
       ^-  (unit (unit cage))
-      ?.  ?=([@ %vita *] path)
-        (on-peek:ag path)
-      ?+  path  [~ ~]
-        [%u %vita ~]                 ``noun+!>(&)
-        [%x %vita %last ~]           ``noun+!>(last)
-        [%x %vita %enabled ~]        ``noun+!>(enabled.config)
-      ==
+      (on-peek:ag path)
     ::
     ++  on-agent
       |=  [=wire =sign:agent:gall]

--- a/vita/app/vita.hoon
+++ b/vita/app/vita.hoon
@@ -297,8 +297,9 @@
   %-  turn  :_  head
   %+  skim  ~(tap in .^((set [@p rave:clay]) %cx /[our]//[now]/cult/[desk]))
   |=  [@p rav=rave:clay]
-  ?.  ?=([%sing %w [%ud @] ~] rav)  %|
-  =(+(car) +>->.rav)
+  ?&  ?=([%sing %w [%ud @] ~] rav)
+      .=(+(car) +>->.rav))
+  ==
 ::
 ++  scry-treaty-alliance
   .^(update:alliance:tt %gx /[(scot %p our.bowl)]/treaty/[(scot %da now.bowl)]/alliance/noun)

--- a/vita/app/vita.hoon
+++ b/vita/app/vita.hoon
@@ -292,13 +292,12 @@
   ^-  (set ship)
   =-  ((slog leaf+"vita: our {<desk>} has {<(lent ~(tap in -))>} subs" ~) -)
   =+  [our=(scot %p our.bowl) now=(scot %da now.bowl)]
-  =+  car=ud:.^(cass:clay %cw /[our]/[desk]/[now])
   %-  sy
   %-  turn  :_  head
   %+  skim  ~(tap in .^((set [@p rave:clay]) %cx /[our]//[now]/cult/[desk]))
   |=  [@p rav=rave:clay]
   ?&  ?=([%sing %w [%ud @] ~] rav)
-      .=(+(car) +>->.rav))
+      .=(+>->.rav +(ud:.^(cass:clay %cw /[our]/[desk]/[now])))
   ==
 ::
 ++  scry-treaty-alliance

--- a/vita/app/vita.hoon
+++ b/vita/app/vita.hoon
@@ -9,7 +9,7 @@
 ::  accept foreign pokes attesting to activity on a desk
 ::  count unique active users each day
 ::  export to csv
-::  
+::
 /-  sur=vita, tt=treaty
 /+  vita
 /+  default-agent, verb, dbug, agentio
@@ -250,7 +250,7 @@
     |=  [time=@da =duct]
     ^-  ?
     ?.  ?=(^ duct)
-      %.n 
+      %.n
     ?=([%gall %use %vita *] i.duct)
   %+  turn  timers
     |=  [time=@da =duct]
@@ -290,10 +290,15 @@
 ++  scry-clay-subs
   |=  [desk=@tas]
   ^-  (set ship)
-  =;  s=(set ship)
-    %-  (slog leaf+"vita: our {<desk>} has {<(lent ~(tap in s))>} subs" ~)
-    s
-  .^((set ship) %cs /[(scot %p our.bowl)]/[desk]/[(scot %da now.bowl)]/subs)
+  =-  ((slog leaf+"vita: our {<desk>} has {<(lent ~(tap in -))>} subs" ~) -)
+  =+  [our=(scot %p our.bowl) now=(scot %da now.bowl)]
+  =+  car=ud:.^(cass:clay %cw /[our]/[desk]/[now])
+  %-  sy
+  %-  turn  :_  head
+  %+  skim  ~(tap in .^((set [@p rave:clay]) %cx /[our]//[now]/cult/[desk]))
+  |=  [@p rav=rave:clay]
+  ?.  ?=([%sing %w [%ud @] ~] rav)  %|
+  =(+(car) +>->.rav)
 ::
 ++  scry-treaty-alliance
   .^(update:alliance:tt %gx /[(scot %p our.bowl)]/treaty/[(scot %da now.bowl)]/alliance/noun)
@@ -400,4 +405,4 @@
       new-met
     new
   ==
--- 
+--


### PR DESCRIPTION
Currently, `%vita` uses the `/c/s/[our]/[desk]/[now]/subs` endpoint in order to determine the number of ships that have downloaded the desk `[desk]` distributed by the host ship `[our]`. Mechanically, this is implemented by tallying the number of outstanding `%clay` subscriptions for various paths within this desk. Unfortunately, not all of these subscriptions represent full desk installs (e.g. [`%hits`](https://github.com/urbit/hits) subscribes to *just* the docket file in a desk), causing this statistic to be greatly inflated.

This PR changes `%vita` to pull subscriptions from the `/c/x/[our]//[now]/cult/[desk]` endpoint, filtered by full desk subscriptions to the latest version of the desk. This data more accurately captures the current number of live subscribers. This PR also includes a couple of smaller changes, i.e. (1) renaming `+share-usage` to `+toggle-vita` and (2) removing the client-side "already sent data" debugging log statement.